### PR TITLE
refactor: remove unnecessary input parameter for uptick workflow

### DIFF
--- a/.github/workflows/_shared-version-uptick.yml
+++ b/.github/workflows/_shared-version-uptick.yml
@@ -3,10 +3,6 @@ name: "Version uptick automation (shared)"
 on:
   workflow_call:
     inputs:
-        target_branch:
-          type: string
-          default: 'develop'
-          required: true
         uptick_config:
           type: string
           required: true
@@ -18,8 +14,6 @@ jobs:
 
     - name: Checkout
       uses: actions/checkout@v3
-      with:
-        ref: ${{ inputs.target_branch }}
 
     - name: Download ESF version upticker tool
       uses: carlosperate/download-file-action@v1

--- a/.github/workflows/_shared-version-uptick.yml
+++ b/.github/workflows/_shared-version-uptick.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - name: Checkout
+    - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
       uses: actions/checkout@v3
 
     - name: Download ESF version upticker tool

--- a/samples/version-uptick.yml
+++ b/samples/version-uptick.yml
@@ -3,10 +3,6 @@ name: "Version uptick automation"
 on:
   workflow_dispatch:
     inputs:
-        target_branch:
-          type: string
-          default: 'develop'
-          required: true
         uptick_config:
           type: choice
           description: Configuration to use for the uptick
@@ -21,5 +17,4 @@ jobs:
   call-workflow-in-public-repo:
     uses: eurotech/add-ons-automation/.github/workflows/_shared-version-uptick.yml@main
     with:
-      target_branch: ${{ inputs.target_branch }}
       uptick_config: ${{ inputs.uptick_config }}


### PR DESCRIPTION
With this PR the `target_branch` field of the action is removed since it was not required.