### PR TITLE
ci: update meaning of `deprecate` commit type

### DIFF
--- a/config/release_notes/template.hbs
+++ b/config/release_notes/template.hbs
@@ -49,10 +49,10 @@ Bug Fixes:
     {{/ifCommitType}}
   {{/commits}}
 {{/ifContainsType}}
-{{! Deprecated APIs section }}
+{{! Deprecated APIs/components section }}
 {{#ifContainsType commits type='deprecate'}}
 
-Deprecated APIs:
+Deprecated APIs/components:
   {{#commits}}
     {{#ifCommitType . type='deprecate'}}
   * {{firstLetters hash number='10'}} - {{{commitDescription .}}} ({{authorName}})


### PR DESCRIPTION
**Brief description of the PR.**: Update the meaning of the `deprecate` commit type for a more general use.

**Description of the solution adopted:** Up until now the `deprecate` commit type was underused due to the specificity we decided to give it. 

With this PR we want to generalise the use of the `deprecate` commit type such that it won't be used only for APIs deprecations.

The motivation is that by using the `refactor` commit type for deprecating components we're not giving them the required importance (in the release notes these commits will be hidden in the changelog section). This PR updates the Release notes template and the documentation for supporting the new meaning of the `deprecate` commit type.

This PR follows: https://github.com/eclipse/kura/pull/4297
