### PR TITLE
feat: ESF add-ons manifest builder automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ In other words: in order to use one of the re-usable workflows contained in the 
 
 ### `config` folder
 
-The `config` folder contains the configuration/template files needed by the re-usable workflows.
+The `config` folder contains the configuration/template files needed by the re-usable workflows and other automation pipelines.

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -35,7 +35,7 @@ def retrieveDescription(filename):
 def main():
     # Get options
     parser = argparse.ArgumentParser(description="Artifact repository manifest.json file builder script")
-    parser.add_argument("-f", "--folder_path", help="Folder path for the desired manifest file", required=True)
+    parser.add_argument("-f", "--folder_path", help="Folder path where the files are stored and where the computed manifest file will be saved", required=True)
     parser.add_argument("-v", "--project_version", help="Project version as reported by maven", required=True)
     parser.add_argument("-n", "--project_name", help="Project name as reported by maven", required=True)
     parser.add_argument("-b", "--build_number", help="Build number as reported by the Jenkins build", required=True)

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -17,6 +17,7 @@ import hashlib
 import json
 import os
 import re
+import logging
 
 
 def compute_MD5_hash(file_path):
@@ -75,7 +76,7 @@ def retrieve_description(filename, csv_descriptions):
         if noext_filename == expected_name:
             return values.get("description")
 
-    print("No match found for '%s'. Setting placeholder description." % base_filename)
+    logging.warning("No match found for '%s'. Setting placeholder description." % base_filename)
     return "placeholder"
 
 

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+
+"""Artifact repository mainfest.json file builder script
+
+This script builds the manifest.json file needed by the artifact repository.
+It will compute the md5 and size of every file in the folder passed as argument
+and correctly populate the manifest.json file in the same directory.
+It also has an interactive mode for setting the description for every file in the
+directory at run-time.
+"""
+
+import os
+import glob
+import hashlib
+import json
+import argparse
+
+
+def main():
+    # Get options
+    parser = argparse.ArgumentParser(description="Artifact repository manifest.json file builder script")
+    parser.add_argument("-f", "--folder_path", help="Folder path for the desired manifest file", required=True)
+    parser.add_argument("-i", "--interactive_mode", help="Enable interactive mode", action="store_true", default=False)
+
+    args = parser.parse_args()
+
+    # Find all files in desired directory
+    path = os.path.abspath(args.folder_path)
+    filenames = glob.glob(os.path.join(path, "*"))
+
+    # If in interactive mode ask user for version
+    version = ""
+    if args.interactive_mode:
+        print("Version of the package: ")
+        version = str(input(">:")).strip()
+        print()
+
+    # Files descriptor array
+    files_array = []
+
+    for filename in filenames:
+        # Compute md5 hash
+        md5hash = ''
+        with open(filename, 'rb') as inputfile:
+            data = inputfile.read()
+            md5hash = hashlib.md5(data).hexdigest()
+
+        # Compute size
+        size = os.path.getsize(filename)
+
+        # Decide visibility
+        visibility = (".dp" in filename or ".txt" in filename)
+
+        # Decide category and description field
+        category = "Add-ons"
+        description = "placeholder"
+        if ".txt" in filename:
+            category = "Release Notes"
+            description = "Release notes"
+
+        # Ask description to user if interactive mode enabled
+        if args.interactive_mode and description == "placeholder":
+            print("Input description for '%s' omitting version ('s' for skipping file)" % os.path.basename(filename))
+            description = str(input(">:")).strip()
+
+            if description.lower() == "s":
+                print()
+                continue
+
+            description = "%s (%s)" % (description, version)
+            print()
+
+        # Append dictionary to files descriptor array
+        files_array.append({
+            "category": category,
+            "description": description,
+            "name": os.path.basename(filename),
+            "visible": visibility,
+            "md5": md5hash,
+            "size": size
+        })
+
+    # Build json object
+    data = {
+        "files": files_array,
+        "product": "placeholder",
+        "version": "placeholder",
+        "public": False
+    }
+
+    # Write json content on file
+    manifest_path = os.path.join(path, 'manifest.json')
+    with open(manifest_path, 'w', encoding='utf-8') as manifest_file:
+        json.dump(data, manifest_file, indent=4, ensure_ascii=False)
+
+    print("Mainfest written to: ", manifest_path)
+
+if __name__ == '__main__':
+    main()

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -33,8 +33,8 @@ def retrieveDescription(filename):
 
 
 def main():
-    # Get options
-    parser = argparse.ArgumentParser(description="Artifact repository manifest.json file builder script")
+    # Get CLI arguments
+    parser = argparse.ArgumentParser(description="ESF Add-ons manifest builder script")
     parser.add_argument("-f", "--folder_path", help="Folder path where the files are stored and where the computed manifest file will be saved", required=True)
     parser.add_argument("-v", "--project_version", help="Project version as reported by maven", required=True)
     parser.add_argument("-n", "--project_name", help="Project name as reported by maven", required=True)
@@ -45,11 +45,6 @@ def main():
     # Find all files in desired directory
     path = os.path.abspath(args.folder_path)
     filenames = glob.glob(os.path.join(path, "*"))
-
-    # Retrieve metadata from command line arguments
-    name = args.project_name
-    version = args.project_version
-    build_number = args.build_number
 
     # Files descriptor array
     files_array = []
@@ -74,7 +69,7 @@ def main():
         # Append dictionary to files descriptor array
         files_array.append({
             "category": category,
-            "description": ("%s (%s)" % (description, version)),
+            "description": ("%s (%s)" % (description, args.project_version)),
             "name": os.path.basename(filename),
             "visible": visibility,
             "md5": md5hash,
@@ -84,8 +79,8 @@ def main():
     # Build json object
     data = {
         "files": files_array,
-        "product": name,
-        "version": ("%s_%s" % (version, build_number)),
+        "product": args.project_name,
+        "version": ("%s_%s" % (args.project_version, args.build_number)),
         "public": False
     }
 

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -35,10 +35,10 @@ def retrieveDescription(filename):
 def main():
     # Get CLI arguments
     parser = argparse.ArgumentParser(description="ESF Add-ons manifest builder script")
-    parser.add_argument("-f", "--folder_path", help="Folder path where the files are stored and where the computed manifest file will be saved", required=True)
-    parser.add_argument("-v", "--project_version", help="Project version as reported by maven", required=True)
-    parser.add_argument("-n", "--project_name", help="Project name as reported by maven", required=True)
-    parser.add_argument("-b", "--build_number", help="Build number as reported by the Jenkins build", required=True)
+    parser.add_argument("-f", "--folder_path", type=str, help="Folder path where the files are stored and where the computed manifest file will be saved", required=True)
+    parser.add_argument("-v", "--project_version", type=str, help="Project version as reported by maven", required=True)
+    parser.add_argument("-n", "--project_name", type=str, help="Project name as reported by maven", required=True)
+    parser.add_argument("-b", "--build_number", type=int, help="Build number as reported by the Jenkins build", required=True)
 
     args = parser.parse_args()
 
@@ -80,7 +80,7 @@ def main():
     data = {
         "files": files_array,
         "product": args.project_name,
-        "version": ("%s_%s" % (args.project_version, args.build_number)),
+        "version": ("%s_%d" % (args.project_version, args.build_number)),
         "public": False
     }
 

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -19,7 +19,7 @@ import os
 import re
 
 
-def parseDescriptionCSVFile(file_path):
+def parse_description_CSV_file(file_path):
     """Parses the CSV file passed as argument and builds a dictionary containing its informations"""
 
     dict = {}
@@ -34,7 +34,7 @@ def parseDescriptionCSVFile(file_path):
     return dict
 
 
-def retrieveCategory(filename):
+def retrieve_category(filename):
     """Retrieves category information for the filename passed as argument"""
 
     if ".txt" in filename:
@@ -43,7 +43,7 @@ def retrieveCategory(filename):
     return "Add-ons"
 
 
-def retrieveDescription(filename, csv_descriptions):
+def retrieve_description(filename, csv_descriptions):
     """Retrieves the description for the filename passed as argument using the CSV file content"""
 
     if ".txt" in filename:
@@ -90,7 +90,7 @@ def main():
     filenames = glob.glob(os.path.join(path, "*"))
 
     # Parse CSV file
-    csv_descriptions = parseDescriptionCSVFile(args.csv_file_path)
+    csv_descriptions = parse_description_CSV_file(args.csv_file_path)
 
     # Files descriptor array
     files_array = []
@@ -109,8 +109,8 @@ def main():
         visibility = (".dp" in filename or ".txt" in filename)
 
         # Decide category and description field
-        category = retrieveCategory(filename)
-        description = retrieveDescription(filename, csv_descriptions)
+        category = retrieve_category(filename)
+        description = retrieve_description(filename, csv_descriptions)
 
         # Append dictionary to files descriptor array
         files_array.append({

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -56,7 +56,11 @@ def retrieve_category(filename):
 
 
 def retrieve_description(filename, csv_descriptions):
-    """Retrieves the description for the filename passed as argument using the CSV file content"""
+    """ Retrieves the description for the filename passed as argument using the CSV file content
+
+        To match the file to the Artifact ID (and then the description) we compare the CSV file content (artifact id + version) and the filename.
+        Knowing the artifact id and the version we can reconstruct the resulting filename and thus match with the corresponding description.
+    """
 
     if ".txt" in filename:
         return "Release notes"

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -19,6 +19,17 @@ import os
 import re
 
 
+def compute_MD5_hash(file_path):
+    """Computes the MD5 hash of the file passed as argument"""
+
+    md5hash = ''
+    with open(file_path, 'rb') as inputfile:
+        data = inputfile.read()
+        md5hash = hashlib.md5(data).hexdigest()
+
+    return md5hash
+
+
 def parse_description_CSV_file(file_path):
     """Parses the CSV file passed as argument and builds a dictionary containing its informations"""
 
@@ -94,23 +105,13 @@ def main():
 
     # Files descriptor array
     files_array = []
-
     for filename in filenames:
-        # Compute md5 hash
-        md5hash = ''
-        with open(filename, 'rb') as inputfile:
-            data = inputfile.read()
-            md5hash = hashlib.md5(data).hexdigest()
-
-        # Compute size
-        size = os.path.getsize(filename)
-
-        # Decide visibility
-        visibility = (".dp" in filename or ".txt" in filename)
-
-        # Decide category and description field
-        category = retrieve_category(filename)
+        # Compute metadata
+        category    = retrieve_category(filename)
         description = retrieve_description(filename, csv_descriptions)
+        visibility  = (".dp" in filename or ".txt" in filename)
+        md5hash     = compute_MD5_hash(filename)
+        size        = os.path.getsize(filename)
 
         # Append dictionary to files descriptor array
         files_array.append({

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -88,8 +88,8 @@ def main():
     parser = argparse.ArgumentParser(description="ESF Add-ons manifest builder script", formatter_class=argparse.RawTextHelpFormatter)
     parser.add_argument("-d", "--debug", dest="loglevel", help="enable debug logging", required=False, default=logging.WARNING, const=logging.DEBUG, action="store_const")
     parser.add_argument("-f", "--folder_path", type=str, help="Folder path where the files are stored and where the computed manifest file will be saved", required=True)
-    parser.add_argument("-v", "--project_version", type=str, help="Project version as reported by maven", required=True)
-    parser.add_argument("-n", "--project_name", type=str, help="Project name as reported by maven", required=True)
+    parser.add_argument("-v", "--project_version", type=str, help="Root project version as reported by maven", required=True)
+    parser.add_argument("-n", "--project_name", type=str, help="Root project ArtifactID as reported by maven", required=True)
     parser.add_argument("-b", "--build_number", type=int, help="Build number as reported by the Jenkins build", required=True)
     parser.add_argument("-c", "--csv_file_path", type=str, required=True,
                         help="File path to the .csv file containing artifact descriptions.\n"

--- a/config/manifest_builder/manifest_builder.py
+++ b/config/manifest_builder/manifest_builder.py
@@ -81,7 +81,7 @@ def retrieve_description(filename, csv_descriptions):
             if artifactID == values.get("description"):
                 logging.warning("ArtifactID and description match for '%s'. Was the pom.xml updated with the correct name?" % artifactID)
 
-            return values.get("description")
+            return ("%s (%s)" % (values.get("description"), values.get("version")))
 
     logging.warning("No match found for '%s'. Setting placeholder description." % base_filename)
     return "placeholder"
@@ -136,7 +136,7 @@ def main():
         # Append dictionary to files descriptor array
         files_array.append({
             "category": category,
-            "description": ("%s (%s)" % (description, args.project_version)),
+            "description": description,
             "name": os.path.basename(filename),
             "visible": visibility,
             "md5": md5hash,

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -1,7 +1,7 @@
 node ("rhel-large") {
     deleteDir()
     def pomVersion
-    def pomProjectName
+    def pomArtifactId
 
     def descriptorsFile = "descriptors.csv"
     def uploadDirectory = "upload"
@@ -14,7 +14,7 @@ node ("rhel-large") {
             ...
             pom = readMavenPom file: 'pom.xml'
             pomVersion = pom.version
-            pomProjectName = pom.artifactId
+            pomArtifactId = pom.artifactId
         }
     }
 
@@ -50,13 +50,13 @@ node ("rhel-large") {
                 cp features/*/target/*.dp ${uploadDirectory}
                 cp bundles/*/target/*.jar ${uploadDirectory}
                 cp bundles/*/target/*.dp ${uploadDirectory}
-                cp RELEASE_NOTES.txt ${uploadDirectory}/RELEASE_NOTES_${pomProjectName}_${pomVersion}.txt
+                cp RELEASE_NOTES.txt ${uploadDirectory}/RELEASE_NOTES_${pomArtifactId}_${pomVersion}.txt
             """
 
             // Download and run python script
             sh """
                 curl wget https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py --output manifest_builder
-                python3 manifest_builder.py -f ${uploadDirectory} -v ${pomVersion} -n ${pomProjectName} -b ${BUILD_NUMBER} -c ${descriptorsFile}
+                python3 manifest_builder.py -f ${uploadDirectory} -v ${pomVersion} -n ${pomArtifactId} -b ${BUILD_NUMBER} -c ${descriptorsFile}
             """
         }
     }
@@ -69,7 +69,7 @@ node ("rhel-large") {
                     files = findFiles(glob: file_path)
                     files.each {
                         println "FILE:  ${it}"
-                        s3Upload acl: 'Private', bucket: 'eth-repo', file: "${it}", metadatas: [''], path: "esf-bundles/${pomProjectName}/${pomVersion}_${BUILD_NUMBER}/"
+                        s3Upload acl: 'Private', bucket: 'eth-repo', file: "${it}", metadatas: [''], path: "esf-bundles/${pomArtifactId}/${pomVersion}_${BUILD_NUMBER}/"
                     }
                 }
             }

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -54,7 +54,7 @@ node ("rhel-large") {
 
             // Download and run python script
             sh """
-                curl https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py --output manifest_builder
+                curl https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py --output manifest_builder.py
                 python3 manifest_builder.py -f ${uploadDirectory} -v ${pomVersion} -n ${pomArtifactId} -b ${BUILD_NUMBER} -c ${descriptorsFile}
             """
         }

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -54,7 +54,7 @@ node ("rhel-large") {
 
             // Download and run python script
             sh """
-                curl wget https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py --output manifest_builder
+                curl https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py --output manifest_builder
                 python3 manifest_builder.py -f ${uploadDirectory} -v ${pomVersion} -n ${pomArtifactId} -b ${BUILD_NUMBER} -c ${descriptorsFile}
             """
         }

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -1,0 +1,73 @@
+node ("rhel-large") {
+    deleteDir()
+    def pomVersion
+    def pomProjectName
+    def descriptorsFile = "descriptors.csv"
+    ...
+
+    stage ("prepare") {
+        sh 'touch ~/.ssh/known_hosts'
+
+        dir("workdir") {
+            ...
+            pom = readMavenPom file: 'pom.xml'
+            pomVersion = pom.version
+            pomProjectName = pom.artifactId
+        }
+    }
+
+    stage ("build") {
+        timeout(time: 2, unit: 'HOURS') {
+            dir("workdir") {
+                withMaven(...)
+        }
+    }
+
+    stage("compute-manifest") {
+        dir("workdir") {
+            // Build descriptor file
+            withMaven(jdk: 'OpenJDK 1.8.0 (latest)', maven: 'Maven 3.5 (latest)', mavenLocalRepo: '${WORKSPACE}/.repository', mavenOpts: '-Dsettings.security=${WORKSPACE}/.repository/settings-security.xml',
+                        mavenSettingsConfig: 'CHANGEME') {
+                configFileProvider([
+                    configFile(fileId: 'CHANGEME',
+                    targetLocation: "${WORKSPACE}/.repository/settings-security.xml")
+                    ]) {
+                        sh "mvn -Dexec.executable=echo -Dexec.args='${project.artifactId},${project.name},${project.version}' --quiet exec:exec > ${descriptorsFile}"
+                }
+            }
+
+            // Copy file into separate folder
+            sh """
+                mkdir upload
+                cp features/*/target/*.dp ./upload
+                cp bundles/*/target/*.jar ./upload
+                cp bundles/*/target/*.dp ./upload
+                cp RELEASE_NOTES.txt ./upload/RELEASE_NOTES_${pomProjectName}_${pomVersion}.txt
+            """
+
+            // Download and run python script
+            file_text = new URL ("https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py").getText()
+            writeFile(file: 'manifest_builder.py', text: file_text)
+
+            sh """
+                python3 manifest_builder.py -f ./upload -v ${pomVersion} -n ${pomProjectName} -b ${BUILD_NUMBER} -c ${descriptorsFile}
+            """
+        }
+    }
+
+    stage("deploy-s3") {
+        if (PUSH_ARTIFACTS.toBoolean()) {
+            withAWS(credentials: 'CHANGEME', region: 'CHANGEME') {
+                dir("workdir") {
+                    files = findFiles(glob: './upload/*')
+                    files.each {
+                        println "FILE:  ${it}"
+                        s3Upload acl: 'Private', bucket: 'eth-repo', file: "${it}", metadatas: [''], path: "esf-bundles/${pomProjectName}/${pomVersion}_${BUILD_NUMBER}/"
+                    }
+                }
+            }
+        } else {
+            echo "Skipping publish artifacts"
+        }
+    }
+}

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -46,10 +46,8 @@ node ("rhel-large") {
             """
 
             // Download and run python script
-            file_text = new URL ("https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py").getText()
-            writeFile(file: 'manifest_builder.py', text: file_text)
-
             sh """
+                curl wget https://raw.githubusercontent.com/eurotech/add-ons-automation/feat/manifest_builder/config/manifest_builder/manifest_builder.py --output manifest_builder
                 python3 manifest_builder.py -f ./upload -v ${pomVersion} -n ${pomProjectName} -b ${BUILD_NUMBER} -c ${descriptorsFile}
             """
         }

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -36,6 +36,12 @@ node ("rhel-large") {
                 }
             }
 
+            // Remove undesired output from CSV file
+            sh """
+                sed -i "/:/d" ${descriptorsFile}
+                sed -i "/-----/d" ${descriptorsFile}
+            """
+
             // Copy file into separate folder
             sh """
                 mkdir upload

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -55,7 +55,7 @@ node ("rhel-large") {
 
             // Download and run python script
             sh """
-                curl wget https://raw.githubusercontent.com/eurotech/add-ons-automation/feat/manifest_builder/config/manifest_builder/manifest_builder.py --output manifest_builder
+                curl wget https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/manifest_builder/manifest_builder.py --output manifest_builder
                 python3 manifest_builder.py -f ${uploadDirectory} -v ${pomVersion} -n ${pomProjectName} -b ${BUILD_NUMBER} -c ${descriptorsFile}
             """
         }

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -32,7 +32,7 @@ node ("rhel-large") {
                     configFile(fileId: 'CHANGEME',
                     targetLocation: "${WORKSPACE}/.repository/settings-security.xml")
                     ]) {
-                        sh "mvn -Dexec.executable=echo -Dexec.args='${project.artifactId},${project.name},${project.version}' --quiet exec:exec > ${descriptorsFile}"
+                        sh "mvn -Dexec.executable=echo -Dexec.args='\${project.artifactId},\${project.name},\${project.version}' --quiet exec:exec > ${descriptorsFile}"
                 }
             }
 

--- a/samples/manifest-builder.groovy
+++ b/samples/manifest-builder.groovy
@@ -47,9 +47,8 @@ node ("rhel-large") {
             // Copy file into separate folder
             sh """
                 mkdir ${uploadDirectory}
-                cp features/*/target/*.dp ${uploadDirectory}
-                cp bundles/*/target/*.jar ${uploadDirectory}
-                cp bundles/*/target/*.dp ${uploadDirectory}
+                cp features/*/target/*.dp ${uploadDirectory} # NOTE: Example only! Refer to original Jenkins configuration
+                cp bundles/*/target/*.jar ${uploadDirectory} # NOTE: Example only! Refer to original Jenkins configuration
                 cp RELEASE_NOTES.txt ${uploadDirectory}/RELEASE_NOTES_${pomArtifactId}_${pomVersion}.txt
             """
 


### PR DESCRIPTION
This PR adds the manifest builder automation script and the required Jenkins pipeline to completely automate the creation of the `manifest.json` file required by the artifact repository.

**Details**: The automation is split in two parts:
- The manifest builder Python script (`manifest_builder.py`)
- The sample Jenkins pipeline required for running the script (`manifest-builder.groovy`)

## Manifest builder Python script

The manifest builder Python script is responsible for:
- Computing the MD5 hash for every file
- Computing the size for every file
- Computing the metadata for every artifact (name, description, version etc.)
- Writing all these metadata in the target `manifest.json`)

To do so it requires the following:
- `folder_path`: Folder path where the files we're interested in uploading and for which we want to compute the metadata are stored. The resulting computed manifest file will be saved here.
- `project_version`: Project version as reported by maven (can be retrieved with: `mvn -Dexec.executable=echo -Dexec.args='${project.version}' --quiet exec:exec --non-recursive`)
- `project_name`: Project ArtifactID as reported by maven (can be retrieved with: `mvn -Dexec.executable=echo -Dexec.args='${project.artifactId}' --quiet exec:exec --non-recursive`)
- `build_number`:  Build number as reported by the Jenkins build
- `csv_file_path`: File path to the .csv file containing artifact descriptions. The file can be generated with the following command:
```bash
mvn --file ./pom.xml 
    -Dexec.executable=echo
    -Dexec.args='${project.artifactId},${project.name},${project.version}'
    --quiet exec:exec > file.csv
```

**:warning: Note**: To be able to generate this CSV file, the project **must be updated** such that every artifact we're interested in uploading has the `name` property populated.

Example:

```xml
...
<artifactId>com.eurotech.framework.mbus.bindings.x86_64</artifactId>
<name>MBus Bindings x86_64 Jar</name>
<packaging>eclipse-plugin</packaging>
...
```

#### Script help

```bash
usage: manifest_builder.py [-h] [-d] -f FOLDER_PATH -v PROJECT_VERSION -n PROJECT_NAME -b BUILD_NUMBER -c CSV_FILE_PATH

ESF Add-ons manifest builder script

optional arguments:
  -h, --help            show this help message and exit
  -d, --debug           enable debug logging
  -f FOLDER_PATH, --folder_path FOLDER_PATH
                        Folder path where the files are stored and where the computed manifest file will be saved
  -v PROJECT_VERSION, --project_version PROJECT_VERSION
                        Root project version as reported by maven
  -n PROJECT_NAME, --project_name PROJECT_NAME
                        Root project ArtifactID as reported by maven
  -b BUILD_NUMBER, --build_number BUILD_NUMBER
                        Build number as reported by the Jenkins build
  -c CSV_FILE_PATH, --csv_file_path CSV_FILE_PATH
                        File path to the .csv file containing artifact descriptions.
                        The file can be generated with the following command:
                        mvn --file ./pom.xml
                            -Dexec.executable=echo
                            -Dexec.args='${project.artifactId},${project.name},${project.version}'
                            --quiet exec:exec > file.csv
```

## Sample Jenkins pipeline

Under the `sample` folder I added an example Jenkins pipeline that can be used as a template for adding this automation to all the add-ons.

The Jenkins pipeline is responsible for:
- Generating the CSV file
- Retrieving the project version from the pom
- Retrieving the project id from the pom
- Retrieving the build number from Jenkins
- Moving all the files we're interested in uploading in a separate folder
- Running the `manifest_builder.py` script with the required informations
- Uploading all the files to S3

> **Note**: The script has no dependency, everything comes from the Python standard library.