### PR TITLE
fix: avoid branch name collision on Version Uptick workflow

### DIFF
--- a/.github/workflows/_shared-version-uptick.yml
+++ b/.github/workflows/_shared-version-uptick.yml
@@ -64,4 +64,4 @@ jobs:
           Automated changes by [_Version uptick automation_](https://github.com/eurotech/add-ons-automation/blob/main/.github/workflows/_shared-version-uptick.yml) action.
           - Automated uptick to ${{ steps.get-version.outputs.resolved-version }} version.
           - Automation ran using `${{ inputs.uptick_config }}` configuration.
-        branch-suffix: short-commit-hash
+        branch-suffix: timestamp


### PR DESCRIPTION
For the uptick workflow it can happen that the you'll need to update two branches (the release and the development one) at the same time. They most probably share the last commit hash and therefore you can have a branch name collision for the uptick workflow.

We updated the `branch-suffix` to use the `timestamp` instead of the `short-commit-hash` to avoid future collisions.

Therefore we'll now see the following branch names:

![image](https://github.com/eurotech/add-ons-automation/assets/22748355/e48d1222-4756-4a01-9a88-49ab86605249)

Instead of:

![image](https://github.com/eurotech/add-ons-automation/assets/22748355/06d87cda-8e46-4e0c-abcf-347b2c0a4369)

**Note**: I didn't update the other workflows since the scenario in which we have multiple workflows running on the same commit should not happen and we might actually want PR to overwrite the same branch (Release Notes)