### PR TITLE
ci: pin versions of Actions and Reusable Workflows

### DIFF
--- a/.github/workflows/_shared-backport.yml
+++ b/.github/workflows/_shared-backport.yml
@@ -18,7 +18,7 @@ jobs:
         )
       )
     steps:
-      - uses: tibdex/backport@v2
+      - uses: tibdex/backport@9565281eda0731b1d20c4025c43339fb0a23812e # v2.0.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           title_template: "<%= title %> [backport <%= base %>]"

--- a/.github/workflows/_shared-build-deploy-docs.yml
+++ b/.github/workflows/_shared-build-deploy-docs.yml
@@ -7,12 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0
 
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4.9.1
         with:
           python-version: '3.12'
 

--- a/.github/workflows/_shared-first-time-setup.yml
+++ b/.github/workflows/_shared-first-time-setup.yml
@@ -23,10 +23,10 @@ jobs:
     steps:
 
     - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Download ESF archetype
-      uses: carlosperate/download-file-action@v1
+      uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       id: download-file
       with:
         file-url: ${{ github.event.inputs.archetype_url }}
@@ -56,7 +56,7 @@ jobs:
       shell: bash
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
         title: "chore: repository initialization from ESF archetype"
         commit-message: "chore: repository initialization from ESF archetype"

--- a/.github/workflows/_shared-pr-lint.yml
+++ b/.github/workflows/_shared-pr-lint.yml
@@ -7,7 +7,7 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 # v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/_shared-release-notes.yml
+++ b/.github/workflows/_shared-release-notes.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
 
     - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       with:
         fetch-depth: '0'
 
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'temurin' # See 'Supported distributions' for available options
         java-version: '11' # Required by the git-changelog-command-line tool
@@ -48,18 +48,18 @@ jobs:
 
     - name: Download git-changelog-command-line tool
       id: download-changelog-cli
-      uses: carlosperate/download-file-action@v1
+      uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
         file-url: https://repo1.maven.org/maven2/se/bjurr/gitchangelog/git-changelog-command-line/1.100.2/git-changelog-command-line-1.100.2.jar
         md5: 09d5fc8b57b3fa9adb94c8d207630cfc
 
     - name: Download release notes template
-      uses: carlosperate/download-file-action@v1
+      uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
         file-url: https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/release_notes/template.hbs
 
     - name: Download release notes helper
-      uses: carlosperate/download-file-action@v1
+      uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
         file-url: https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/release_notes/helper.hbs
 
@@ -88,7 +88,7 @@ jobs:
       shell: bash
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
         title: "chore: add ${{ steps.get-version.outputs.resolved-version }} release notes"
         commit-message: "chore: add ${{ steps.get-version.outputs.resolved-version }} release notes"

--- a/.github/workflows/_shared-version-uptick.yml
+++ b/.github/workflows/_shared-version-uptick.yml
@@ -13,15 +13,15 @@ jobs:
     steps:
 
     - name: Checkout ${{ github.ref }} branch in ${{ github.repository }} repository.
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
     - name: Download ESF version upticker tool
-      uses: carlosperate/download-file-action@v1
+      uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
         file-url: https://kura-repo.s3.us-west-2.amazonaws.com/esf_upticker_tool/version-uptick-0.1.0-linux-x86_64
 
     - name: Download desired upticker configuration file
-      uses: carlosperate/download-file-action@v1
+      uses: carlosperate/download-file-action@8b89cb8b4807765e7d63fe765cc600eb1919af11 # v1.1.2
       with:
         file-url: https://raw.githubusercontent.com/eurotech/add-ons-automation/main/config/version_uptick/${{ inputs.uptick_config }}
 
@@ -56,7 +56,7 @@ jobs:
       shell: bash
 
     - name: Create Pull Request
-      uses: peter-evans/create-pull-request@v4
+      uses: peter-evans/create-pull-request@38e0b6e68b4c852a5500a94740f0e535e0d7ba54 # v4.2.4
       with:
         title: "chore: automated uptick to ${{ steps.get-version.outputs.resolved-version }}"
         commit-message: "chore: automated uptick to ${{ steps.get-version.outputs.resolved-version }}"


### PR DESCRIPTION
Pin version of Actions and Reusable Workflows in our automations as per Eclipse Foundation security recommendations.

I used https://github.com/suzuki-shunsuke/pinact to perform the pinning for all actions.

The action that were not pinned use Reusable Workflow that we developed and therefore are considered safe.